### PR TITLE
Automatic Ticket Number Tracking

### DIFF
--- a/routes/transactions/new.go
+++ b/routes/transactions/new.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mongodb.org/mongo-driver/bson"
 
+	"github.com/unikino-gegenlicht/cinema-management-backend/database"
 	"github.com/unikino-gegenlicht/cinema-management-backend/middleware"
 	"github.com/unikino-gegenlicht/cinema-management-backend/types"
 )
@@ -30,6 +31,36 @@ func newTransaction(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+
+	// to allow tracking the numver of issued tickets now get the items from the
+	// database
+	itemCollection := database.Database.Collection("items")
+	results, err := itemCollection.Find(r.Context(), bson.D{})
+	if err != nil {
+		log.Error().Err(err).Msg("unable to retrieve items")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	var items []types.Item
+	err = results.All(r.Context(), &items)
+	if err != nil {
+		log.Error().Err(err).Msg("unable to retrieve items")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	var ticketCount uint
+	for _, itemId := range transaction.Items {
+		for _, item := range items {
+			if item.ID == itemId {
+				ticketCount += item.TicketCount
+			}
+		}
+	}
+
+	log.Debug().Uint("tickets", ticketCount).Msg("issuing new tickets")
+	// todo: issue tickets
 
 	// now insert the transaction
 	_, err = collection.ReplaceOne(r.Context(), bson.D{{"_id", transaction.ID}}, transaction)

--- a/types/item.go
+++ b/types/item.go
@@ -8,9 +8,17 @@ package types
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
 type Item struct {
-	ID    *primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
-	Name  string              `bson:"name" json:"name"`
-	Price float64             `bson:"price" json:"price"`
-	Icon  string              `bson:"icon" json:"icon"`
-	Flags *[]string           `bson:"flags,omitempty" json:"flags,omitempty"`
+	// ID contains the unique ID of an item used to identify it in the backend
+	ID *primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
+	// Name contains the displayed name of the item in the frontend
+	Name string `bson:"name" json:"name"`
+	// Price contains the price of the item which can be negative to allow
+	// discounts
+	Price float64 `bson:"price" json:"price"`
+	// Icon contains the identifier of the icon that is displayed next to the
+	// item's name to allow an easier identification of the item in the forntend
+	Icon string `bson:"icon" json:"icon"`
+	// IssueTicket is a boolean specifying if a ticket is issued on the
+	// purchase of this item
+	IssueTicket bool `bson:"issueTicket" json:"issueTicket"`
 }

--- a/types/item.go
+++ b/types/item.go
@@ -21,4 +21,7 @@ type Item struct {
 	// IssueTicket is a boolean specifying if a ticket is issued on the
 	// purchase of this item
 	IssueTicket bool `bson:"issueTicket" json:"issueTicket"`
+	// TicketCount is an unsigned integer specifying how many tickets are to
+	// be issued on the purchase of the item. If it is not set it will not be
+	TicketCount uint `bson:"ticketCount" json:"ticketCount"`
 }

--- a/types/ticket.go
+++ b/types/ticket.go
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023.  Jan Eike Suchard. All rights reserved
+ * SPDX-License-Identifier: MIT
+ */
+
+package types
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type Ticket struct {
+	// ID contains the unique id of the ticket used to identify it in
+	// the backend and in other non-human-readable media types
+	ID *primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
+
+	// Holder contains the name of the person that ticket has been issued to
+	Holder string `bson:"holder,omitempty" json:"holder,omitempty"`
+
+	// IssuedAt contains the date and time the ticket has been issued
+	IssuedAt time.Time `bson:"issuedAt" json:"issuedAt"`
+}

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -17,7 +17,7 @@ type Transaction struct {
 	Amount            float64               `bson:"amount" json:"amount"`
 	Title             string                `bson:"title" json:"title"`
 	Description       string                `bson:"description" json:"description"`
-	Items             *[]primitive.ObjectID `bson:"items,omitempty" json:"items,omitempty"`
+	Items             []*primitive.ObjectID `bson:"items,omitempty" json:"items,omitempty"`
 	Register          primitive.ObjectID    `bson:"register" json:"register"`
 	CustomItems       *[]Item               `bson:"custom-items,omitempty" json:"customItems,omitempty"`
 	PaymentType       string                `bson:"paymentType" json:"paymentType"`


### PR DESCRIPTION
This PR introduces an automated ticket tracking api in the backend which allows to keep up with the number of issued tickets and the number of tickets.
It allows revoking a single ticket if the purchase is cancelled

If this PR is merged it closes #1